### PR TITLE
Move android workflow trigger from v0.7 to main branch

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,7 +3,7 @@ name: Android CI
 on:
   push:
     branches:
-      - v0.7
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
If I understand correctly this should make it so that pushing to main, and not just v0.7 branch, triggers the android workflow, which builds an android app bundle and uploads it to the Google Play internal testing track

(Merging this PR should trigger the workflow)